### PR TITLE
kirchoff's law flag

### DIFF
--- a/src/nulib.F90
+++ b/src/nulib.F90
@@ -509,10 +509,12 @@ module nulib
            temporary_spectra(1,1:number_groups)/blackbody_spectra(1,1:number_groups)
       absorption_opacity(2,1:number_groups) = absorption_opacity(2,1:number_groups) + &
            temporary_spectra(2,1:number_groups)/blackbody_spectra(2,1:number_groups)
-      emissivities(1,1:number_groups) = emissivities(1,1:number_groups) + &
-           temporary_spectra(1,1:number_groups)
-      emissivities(2,1:number_groups) = emissivities(2,1:number_groups) + &
-           temporary_spectra(2,1:number_groups)
+      if (apply_kirchoff_to_pair_creation) then
+         emissivities(1,1:number_groups) = emissivities(1,1:number_groups) + &
+              temporary_spectra(1,1:number_groups)
+         emissivities(2,1:number_groups) = emissivities(2,1:number_groups) + &
+              temporary_spectra(2,1:number_groups)
+      end if
 
       if(debug) then
          write(*,*) "debug #4: absorption opacities after \eta/B_\nu term for species 1:", &
@@ -528,9 +530,11 @@ module nulib
               temporary_spectra(4,1:number_groups)/blackbody_spectra(3,1:number_groups) + & 
               temporary_spectra(5,1:number_groups)/blackbody_spectra(3,1:number_groups) + &
               temporary_spectra(6,1:number_groups)/blackbody_spectra(3,1:number_groups))/4.0d0
-         emissivities(3,1:number_groups) = emissivities(3,1:number_groups) + &
-              temporary_spectra(3,1:number_groups) + temporary_spectra(4,1:number_groups) + &
-              temporary_spectra(5,1:number_groups) + temporary_spectra(6,1:number_groups)
+         if (apply_kirchoff_to_pair_creation) then
+            emissivities(3,1:number_groups) = emissivities(3,1:number_groups) + &
+                 temporary_spectra(3,1:number_groups) + temporary_spectra(4,1:number_groups) + &
+                 temporary_spectra(5,1:number_groups) + temporary_spectra(6,1:number_groups)
+         end if
 
       !average neutrinos and antineutrinos individually
       else if (number_local_species.eq.4) then
@@ -540,10 +544,12 @@ module nulib
          absorption_opacity(4,1:number_groups) = absorption_opacity(4,1:number_groups) + &
               (temporary_spectra(4,1:number_groups)/blackbody_spectra(3,1:number_groups) + &
               temporary_spectra(6,1:number_groups)/blackbody_spectra(3,1:number_groups))/2.0d0
-         emissivities(3,1:number_groups) = emissivities(3,1:number_groups) + &
-              temporary_spectra(3,1:number_groups) + temporary_spectra(5,1:number_groups)
-         emissivities(4,1:number_groups) = emissivities(4,1:number_groups) + &
-              temporary_spectra(4,1:number_groups) + temporary_spectra(6,1:number_groups)
+         if (apply_kirchoff_to_pair_creation) then
+            emissivities(3,1:number_groups) = emissivities(3,1:number_groups) + &
+                 temporary_spectra(3,1:number_groups) + temporary_spectra(5,1:number_groups)
+            emissivities(4,1:number_groups) = emissivities(4,1:number_groups) + &
+                 temporary_spectra(4,1:number_groups) + temporary_spectra(6,1:number_groups)
+         end if
 
       !no averaging at all, what six different species
       else if (number_local_species.eq.6) then
@@ -555,14 +561,16 @@ module nulib
               temporary_spectra(5,1:number_groups)/blackbody_spectra(3,1:number_groups)
          absorption_opacity(6,1:number_groups) = absorption_opacity(6,1:number_groups) + &
               temporary_spectra(6,1:number_groups)/blackbody_spectra(3,1:number_groups)
-         emissivities(3,1:number_groups) = emissivities(3,1:number_groups) + &
-              temporary_spectra(3,1:number_groups)
-         emissivities(4,1:number_groups) = emissivities(4,1:number_groups) + &
-              temporary_spectra(4,1:number_groups)
-         emissivities(5,1:number_groups) = emissivities(5,1:number_groups) + &
-              temporary_spectra(5,1:number_groups)
-         emissivities(6,1:number_groups) = emissivities(6,1:number_groups) + &
-              temporary_spectra(6,1:number_groups)
+         if (apply_kirchoff_to_pair_creation) then
+            emissivities(3,1:number_groups) = emissivities(3,1:number_groups) + &
+                 temporary_spectra(3,1:number_groups)
+            emissivities(4,1:number_groups) = emissivities(4,1:number_groups) + &
+                 temporary_spectra(4,1:number_groups)
+            emissivities(5,1:number_groups) = emissivities(5,1:number_groups) + &
+                 temporary_spectra(5,1:number_groups)
+            emissivities(6,1:number_groups) = emissivities(6,1:number_groups) + &
+                 temporary_spectra(6,1:number_groups)
+         end if
 
       endif
 

--- a/src/requested_interactions.inc
+++ b/src/requested_interactions.inc
@@ -67,6 +67,8 @@
   logical :: add_nutau_emission_NNBrems = .true.
   logical :: add_anutau_emission_NNBrems = .true.
 
+  logical :: apply_kirchoff_to_pair_creation = .true.
+
   !kernels for full calculation of thermal processes
   logical :: add_nue_kernel_epannihil = .false.
   logical :: add_anue_kernel_epannihil = .false.


### PR DESCRIPTION
Hey Evan,

I just added a flag to be able to turn off applying Kirchoff's law to the pair-creation emissivities (since it's technically incorrect, as you mention). The default flag is set to keep the default behavior unchanged.
