### PR TITLE
fixed openmp bug

### DIFF
--- a/src/eos_interface.F90
+++ b/src/eos_interface.F90
@@ -88,17 +88,16 @@ subroutine set_eos_variables(eos_variables)
      write(*,*) "ERROR: ye values don't match"
      stop
   end if
-  
 
-  ! set the input vector. pipeline is only 1 element long
+  ! call the eos
+  !$OMP CRITICAL
   temp_row(1) = eos_variables(tempindex)/kelvin_to_mev
   den_row(1)  = eos_variables(rhoindex)
   abar_row(1) = HELM_abar
   zbar_row(1) = HELM_zbar
   jlo_eos = 1 ; jhi_eos = 1
-
-  ! call the eos
   call helmeos
+  !$OMP END CRITICAL
 
   !set eos_variables
   eos_variables(energyindex) = etot_row(1)


### PR DESCRIPTION
There is still an issue at exactly Ye=0.5, but the openmp bug is fixed. It turns out we have to include the several variable assignments before the eos call in the critical block, because those are actually helmholtz varibales and not nulib variables. If optimization is important, one could call the eos for many values at once, but I think it works fine the way it is now (as long as you stay away from ye=0.5)
