### PR TITLE
some fixes to non-weak rates useability

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,6 +42,7 @@ endif
 		   weakrates/interface.F90 \
 
 	DEFS += -DWEAK_RATES 
+
 endif
 
 
@@ -65,9 +66,6 @@ ifeq ($(MPI),1)
 	DEFS += -D__MPI__
 endif
 
-
-EXTRADEPS = requested_interactions.inc constants.inc
-
 MOD_OBJECTS=$(MODULES:.F90=.o )
 OBJECTS=$(SOURCES:.F90=.o )
 NT_OBJECTS=$(NT_SOURCES:.F90=.o )
@@ -83,7 +81,7 @@ ifeq ($(HELMHOLTZ_EOS),1)
 else
 	DEFS += -DHAVE_NUC_EOS
 endif
-EXTRADEPS += requested_interactions.inc constants.inc
+EXTRADEPS += requested_interactions.inc constants.inc ../make.inc
 EXTRAINCS += $(HDF5INCS)
 EXTRAOBJECTS += $(HDF5LIBS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ ifeq ($(HELMHOLTZ_EOS),1)
 else
 	DEFS += -DHAVE_NUC_EOS
 endif
-EXTRADEPS += requested_interactions.inc constants.inc ../make.inc
+EXTRADEPS += requested_interactions.inc constants.inc ../make.inc Makefile
 EXTRAINCS += $(HDF5INCS)
 EXTRAOBJECTS += $(HDF5LIBS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,42 +1,49 @@
 include ../make.inc
 
-SOURCES=nulib.F90\
-	input_parser.F90 \
-	nuclei_distribution_helpers.F90 \
-	weakrates/ratetable.F90 \
-	weakrates/rateapprox.F90 \
-	weakrates/ratelibrary.F90 \
-	weakrates/interface.F90 \
-	fermi.F90 \
-	helpers.F90 \
-	gauss_laguerre_helpers.F90 \
-	gauss_legendre_helpers.F90 \
-	electron_positron_annihilation.F90 \
-	absorption_crosssections.F90 \
-	emissivities.F90 \
-	scattering.F90 \
-	weak_magnetism_correction.F90 \
-	inelastic_electron_scattering.F90 \
-	eos_interface.F90
+MODULES = nulib.F90 \
+	  input_parser.F90
+
+SOURCES = fermi.F90 \
+	  helpers.F90 \
+	  gauss_laguerre_helpers.F90 \
+	  gauss_legendre_helpers.F90 \
+	  electron_positron_annihilation.F90 \
+	  absorption_crosssections.F90 \
+	  emissivities.F90 \
+	  scattering.F90 \
+	  weak_magnetism_correction.F90 \
+	  inelastic_electron_scattering.F90 \
+	  eos_interface.F90
 
 NT_SOURCES=nulibtable.F90 \
 	   nulibtable_reader.F90 \
 	   linterp_many_mod.F90
 
 
-#the weak_rates module requires M. Hempel's
-#EOS dependent NSE distributions
-ifeq ($(WEAK_RATES),1)
-	NUCLEI_HEMPEL=1
-	DEFS += -DWEAK_RATES 
-endif
-
 ifeq ($(NUCLEI_HEMPEL),1)
+	MODULES += nuclei_distribution_helpers.F90
 	F_SOURCES = extra_code_and_tables/sfho_frdm_comp/sfho_frdm_composition_module.f
 	F_OBJECTS=$(F_SOURCES:.f=.o )
 	MODINC += -I./extra_code_and_tables/sfho_frdm_comp
 	DEFS += -DNUCLEI_HEMPEL 
 endif
+
+
+#the weak_rates module requires M. Hempel's
+#EOS dependent NSE distributions
+ifeq ($(WEAK_RATES),1)
+ifeq ($(NUCLEI_HEMPEL),0)
+$(error NUCLEI_HEMPEL must be 1 for weakrates)
+endif
+
+	MODULES += weakrates/ratetable.F90 \
+		   weakrates/rateapprox.F90 \
+		   weakrates/ratelibrary.F90 \
+		   weakrates/interface.F90 \
+
+	DEFS += -DWEAK_RATES 
+endif
+
 
 #dual openmp+mpi jobs may work, but are not currently supported
 ifeq ($(OPENMP),1)
@@ -61,6 +68,7 @@ endif
 
 EXTRADEPS = requested_interactions.inc constants.inc
 
+MOD_OBJECTS=$(MODULES:.F90=.o )
 OBJECTS=$(SOURCES:.F90=.o )
 NT_OBJECTS=$(NT_SOURCES:.F90=.o )
 
@@ -88,23 +96,26 @@ endif
 ../nulibtable_driver:  $(EXTRADEPS) $(NT_OBJECTS) $(F_OBJECTS) 
 	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINC) -o $@ nulibtable_driver.F90 $(NT_OBJECTS) $(EXTRAOBJECTS)
 
-../point_example:  $(EXTRADEPS) $(F_OBJECTS) $(OBJECTS) point_example.F90
-	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o $@ point_example.F90 $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
+../point_example:  $(EXTRADEPS) $(F_OBJECTS) $(MOD_OBJECTS) $(OBJECTS) point_example.F90
+	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o $@ point_example.F90 $(MOD_OBJECTS) $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
 
-../make_table_example:  $(EXTRADEPS) $(F_OBJECTS) $(OBJECTS) make_table_example.F90
-	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o $@ make_table_example.F90 $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
+../make_table_example:  $(EXTRADEPS) $(F_OBJECTS) $(MOD_OBJECTS) $(OBJECTS) make_table_example.F90
+	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o $@ make_table_example.F90 $(MOD_OBJECTS) $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
 
-../make_table_weakrates:  $(EXTRADEPS) $(F_OBJECTS) $(OBJECTS) make_table_weakrates.F90
-	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o $@ make_table_weakrates.F90 $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
+../make_table_weakrates:  $(EXTRADEPS) $(F_OBJECTS) $(MOD_OBJECTS) $(OBJECTS) make_table_weakrates.F90
+	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o $@ make_table_weakrates.F90 $(MOD_OBJECTS) $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
 
-nulib.a: $(EXTRADEPS) $(F_OBJECTS) $(OBJECTS) $(NT_OBJECTS)
+nulib.a: $(EXTRADEPS) $(F_OBJECTS) $(MOD_OBJECTS) $(OBJECTS) $(NT_OBJECTS)
 	ar -r nulib.a *.o
 
-test:	$(EXTRADEPS) $(F_OBJECTS) $(OBJECTS)  test.F90
-	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o test test.F90 $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
+test:	$(EXTRADEPS) $(F_OBJECTS) $(MOD_OBJECTS) $(OBJECTS)  test.F90
+	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -o test test.F90 $(MOD_OBJECTS) $(OBJECTS) $(F_OBJECTS) $(EXTRAOBJECTS)
 
 
 $(OBJECTS): %.o: %.F90 $(EXTRADEPS)
+	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -c $< -o $@
+
+$(MOD_OBJECTS): %.o: %.F90 $(EXTRADEPS)
 	$(F90) $(F90FLAGS) $(DEFS) $(MODINC) $(EXTRAINCS) -c $< -o $@
 
 $(F_OBJECTS): %.o: %.f 

--- a/src/emissivities.F90
+++ b/src/emissivities.F90
@@ -362,7 +362,9 @@ end subroutine total_emissivities
 subroutine return_emissivity_spectra_given_neutrino_scheme(emissivity_spectra,eos_variables)
 
   use nulib
+#if WEAK_RATES
   use weakrates_interface
+#endif
   implicit none
   
   !inputs & outputs
@@ -377,14 +379,6 @@ subroutine return_emissivity_spectra_given_neutrino_scheme(emissivity_spectra,eo
 
   !function dec
   real*8 :: get_fermi_integral
-
-  !bounds checking       
-  real*8 :: t9
-  real*8 :: lrhoYe
-
-  lrhoYe = log10(eos_variables(rhoindex)*eos_variables(yeindex))
-  t9 = (eos_variables(tempindex)/kelvin_to_mev)/(10.0d0**9.0d0)
-
 
   if (size(emissivity_spectra,1).ne.number_species) then
      stop "return_emissivity_spectra_given_neutrino_scheme:provided array has wrong number of species"

--- a/src/make_table_example.F90
+++ b/src/make_table_example.F90
@@ -3,7 +3,9 @@ program make_table_example
   
   use nulib
   use inputparser
+#if NUCLEI_HEMPEL
   use nuclei_hempel
+#endif
   implicit none
 #ifdef __MPI__
   include 'mpif.h'

--- a/src/point_example.F90
+++ b/src/point_example.F90
@@ -3,7 +3,9 @@ program point_example
 
   use nulib
   use inputparser
+#if NUCLEI_HEMPEL
   use nuclei_hempel, only : set_up_Hempel
+#endif
   implicit none
 
   !many people use different number of species, this is to denote how they are devided up.
@@ -57,7 +59,9 @@ program point_example
   !this sets up many cooefficients and creates the energy grid (one
   !zone + log spacing) see nulib.F90:initialize_nulib
   call initialize_nulib(mypoint_neutrino_scheme,mypoint_number_species,mypoint_number_groups)
+#if NUCLEI_HEMPEL
   call set_up_Hempel ! set's up EOS for nuclear abundances
+#endif
   !read in EOS table & set reference mass
   call read_eos_table(eos_filename)
   m_ref = m_amu !for SFHo_EOS (Hempel)


### PR DESCRIPTION
Some errors existed compiling without weak rates.  It doesn't like the subroutines in nuclei_distribution_helpers because the variables are not defined.  I've fixed it with this code.

This required some changes to the Makefile to correctly set up the dependences.