### PR TITLE
Add two python scripts to NuLib for storing/extracting source code in/from HDF5 NuLib table

### DIFF
--- a/nulib_extract_source_from_table.py
+++ b/nulib_extract_source_from_table.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python 
+
+""" 
+    Script that takes a NuLib table, checks
+    if the source code is present. If so, 
+    it extracts the source tarball from 
+    the hdf5 file and places it into a 
+    separate directory.
+
+    Requires h5py and numpy and their dependencies.
+"""
+
+import os
+import sys
+import fnmatch
+import glob
+import h5py
+import numpy as np
+
+
+if len(sys.argv) < 2:
+    print "Usage: nulib_extract_source_in_table.py <NuLib Table Name>"
+    sys.exit()
+
+nulib_table_name = sys.argv[1]
+
+tarfile = "nulib_src.tar.gz"
+
+# creating output directory
+print "Creating output directory saved_nulib"
+os.system("mkdir saved_nulib")
+
+h5file = h5py.File(nulib_table_name,"r")
+
+try:
+    indata = h5file['NuLib Source'][()]
+except:
+    print "Sorry, no source availabe in this NuLib file."
+    h5file.close()
+    sys.exit()
+
+h5file.close()
+
+outfile = open("saved_nulib/"+tarfile,"wb")
+outfile.write(indata)
+outfile.close()
+
+

--- a/nulib_include_source_in_table.py
+++ b/nulib_include_source_in_table.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python 
+
+""" 
+    Script that takes the NuLib source code and
+    parameter file, creates a tarball, and includes
+    that tarball in the NuLib table.
+    Requires h5py and numpy and their dependencies.
+"""
+
+import os
+import sys
+import fnmatch
+import glob
+import h5py
+import numpy as np
+
+
+if len(sys.argv) < 2:
+    print "Usage: nulib_include_source_in_table.py <NuLib Table Name>"
+    sys.exit()
+
+nulib_table_name = sys.argv[1]
+
+# make file list
+filelist = []
+filelist.append("Makefile")
+filelist.append("make.inc")
+filelist.append("parameters")
+filelist.append("README")
+
+matches = []
+for root, dirnames, filenames in os.walk('src'):
+    for filename in fnmatch.filter(filenames, '*.F90') + \
+        fnmatch.filter(filenames, '*.f') + fnmatch.filter(filenames, 'Makefile') +\
+        fnmatch.filter(filenames, 'NuLib_README') + fnmatch.filter(filenames, '*.inc'):
+        matches.append(os.path.join(root, filename))
+
+filelist = filelist + matches
+
+tarfile = "nulib_src.tar.gz"
+tarstring = "tar -czvf " + tarfile + " "
+for xfile in filelist:
+    tarstring = tarstring + xfile + " "
+
+print tarstring
+os.system(tarstring)
+
+infile = open(tarfile,"rb")
+data = infile.read()
+infile.close()
+
+wrapdata = np.void(data)
+
+h5file = h5py.File(nulib_table_name,"r+")
+
+dset = h5file.create_dataset("NuLib Source", data=wrapdata)
+
+h5file.close()


### PR DESCRIPTION
   nulib_include_source_in_table.py <Table File Name> includes
   the source try in the hdf5 file <Table File Name>

   nulib_extract_source_from_table.py <Table File Name> extracts
   a tarball of the source tree if present in <Table File Name>