### PR TITLE
Virial Corrections based on Horowitz et al. (2016) arXiv:1611.05140

### DIFF
--- a/src/requested_interactions.inc
+++ b/src/requested_interactions.inc
@@ -5,6 +5,9 @@
   logical :: do_ionion_correlation = .true.
   logical :: do_heavyscat_formfactor = .true.
   logical :: do_electronpolarization_correction = .true.
+  logical :: do_nc_virial_correction = .false.
+  logical :: do_strange_coupling = .false.
+  real*8, parameter :: gAs = -0.2d0 !dimensionless, for the strange coupling
 
   !absorptions
   logical :: add_nue_absorption_on_n = .true.


### PR DESCRIPTION
This pull request implements two corrections 1. strange quark contributions to the neutrino-nucleon scattering rate (Horowitz 2002) and 2. Virial EOS estimates for the neutrino response. (Horowitz et al. 2016)

1. This simply modifies g_A to include the strange quark contribution (g_A -> g_A - g_A^s for scattering on protons; g_A -> g_A + g_A^s for scattering on neutrons). Based on Horowitz (2002), recently explored by Melson et al. (2015b). We include a new flag for this correction: do_strange_coupling, which defaults to .false. The value of g_A^s can be set via the gAs variable (defaults to -0.2).

2. In Horowitz et al. (2016), estimate for the neutrino response to low density nuclear matter are made via the Virial EOS.  A fitting formula is derived for the neutrino-nucleon elastic scattering.  For lack of a better prescription, the Virial results are smoothly fit to an estimate of Burrow & Sawyer (1998). We implement this fitting formula in NuLib.  We include a new flag for this correction: do_nc_virial_correction, which defaults to .false.
