### PR TITLE
Incremental step toward outputting deltas

### DIFF
--- a/make.inc.template
+++ b/make.inc.template
@@ -23,3 +23,4 @@ HDF5LIBS=-L$(HDF5DIR)/lib -lhdf5 -lhdf5_fortran -lhdf5 -lz
 NUCLEI_HEMPEL = 0
 HELMHOLTZ_EOS = 0
 WEAK_RATES = 0
+DEBUG = 0

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,6 +61,10 @@ else
 endif	
 endif
 
+ifeq ($(DEBUG),1)
+	F90FLAGS += -DDEBUG
+endif
+
 ifeq ($(MPI),1)
 	F90 = mpif90
 	DEFS += -D__MPI__

--- a/src/make_table_example.F90
+++ b/src/make_table_example.F90
@@ -47,6 +47,7 @@ program make_table_example
   real*8, allocatable,dimension(:,:,:,:,:) :: table_emission 
   real*8, allocatable,dimension(:,:,:,:,:) :: table_absopacity
   real*8, allocatable,dimension(:,:,:,:,:) :: table_scatopacity 
+  real*8, allocatable,dimension(:,:,:,:,:) :: table_delta 
 
 
   !final Itable parameters
@@ -74,6 +75,7 @@ program make_table_example
   real*8, allocatable,dimension(:,:) :: local_emissivity
   real*8, allocatable,dimension(:,:) :: local_absopacity
   real*8, allocatable,dimension(:,:) :: local_scatopacity
+  real*8, allocatable,dimension(:,:) :: local_delta
   real*8, allocatable,dimension(:,:) :: local_Phi0
   real*8, allocatable,dimension(:,:) :: local_Phi1
   real*8, allocatable,dimension(:,:,:) :: local_Phi0_epannihil 
@@ -97,6 +99,7 @@ program make_table_example
   real*8, allocatable,dimension(:,:,:,:,:) :: table_emission_node
   real*8, allocatable,dimension(:,:,:,:,:) :: table_absopacity_node
   real*8, allocatable,dimension(:,:,:,:,:) :: table_scatopacity_node
+  real*8, allocatable,dimension(:,:,:,:,:) :: table_delta_node
   real*8, allocatable,dimension(:) :: Itable_temp_subset
   real*8, allocatable,dimension(:,:,:,:,:) :: Itable_Phi0_node
   real*8, allocatable,dimension(:,:,:,:,:) :: Itable_Phi1_node
@@ -208,6 +211,8 @@ program make_table_example
        final_table_size_ye,number_output_species,mytable_number_groups))
   allocate(table_scatopacity(final_table_size_rho,final_table_size_temp, &
        final_table_size_ye,number_output_species,mytable_number_groups))
+  allocate(table_delta(final_table_size_rho,final_table_size_temp, &
+       final_table_size_ye,number_output_species,mytable_number_groups))
 
 #ifdef __MPI__
   !mpi node tables
@@ -216,6 +221,8 @@ program make_table_example
   allocate(table_absopacity_node(final_table_size_rho,final_table_size_temp, &
        final_table_size_ye,number_output_species,mytable_number_groups))
   allocate(table_scatopacity_node(final_table_size_rho,final_table_size_temp, &
+       final_table_size_ye,number_output_species,mytable_number_groups))
+  allocate(table_delta_node(final_table_size_rho,final_table_size_temp, &
        final_table_size_ye,number_output_species,mytable_number_groups))
 
   table_emission_node = 0.0d0
@@ -246,7 +253,7 @@ program make_table_example
 
   !$OMP PARALLEL DO PRIVATE(itemp,iye,local_emissivity,local_absopacity,local_scatopacity, &
   !$OMP ns,ng,eos_variables,keytemp,keyerr,matter_prs,matter_ent,matter_cs2,matter_dedt, &
-  !$OMP matter_dpderho,matter_dpdrhoe) 
+  !$OMP matter_dpderho,matter_dpdrhoe,local_delta) 
 #ifdef __MPI__
   do irho=1,mpi_final_table_size_rho
 #else
@@ -256,6 +263,7 @@ program make_table_example
      allocate(local_emissivity(number_output_species,mytable_number_groups))
      allocate(local_absopacity(number_output_species,mytable_number_groups))
      allocate(local_scatopacity(number_output_species,mytable_number_groups))
+     allocate(local_delta(number_output_species,mytable_number_groups))
      allocate(eos_variables(total_eos_variables))
 #ifdef __MPI__
      write(*,*) "Rho:", 100.0*dble(displs(mpirank)+irho-1)/dble(final_table_size_rho),"%"
@@ -280,7 +288,7 @@ program make_table_example
 
            !calculate the rho,temp,ye
            call single_point_return_all(eos_variables, &
-                local_emissivity,local_absopacity,local_scatopacity, &
+                local_emissivity,local_absopacity,local_scatopacity, local_delta, &
                 mytable_neutrino_scheme)
            
            !check that the number is not NaN or Inf (.gt.1.0d300)
@@ -298,6 +306,11 @@ program make_table_example
                  endif
                  if (local_scatopacity(ns,ng).ne.local_scatopacity(ns,ng)) then
                     write(*,"(a,1P3E18.9,i6,i6)") "We have a NaN in scat", &
+                         eos_variables(rhoindex),eos_variables(tempindex),eos_variables(yeindex),ns,ng
+                    stop
+                 endif
+                 if (local_delta(ns,ng).ne.local_delta(ns,ng)) then
+                    write(*,"(a,1P3E18.9,i6,i6)") "We have a NaN in scat delta", &
                          eos_variables(rhoindex),eos_variables(tempindex),eos_variables(yeindex),ns,ng
                     stop
                  endif
@@ -320,6 +333,18 @@ program make_table_example
                          eos_variables(tempindex),eos_variables(yeindex),ns,ng
                     stop
                  endif
+                 if (local_delta(ns,ng).gt.1.0d0) then
+                    write(*,"(a,1P4E18.9,i6,i6)") "delta > 1", &
+                         local_delta(ns,ng),eos_variables(rhoindex), &
+                         eos_variables(tempindex),eos_variables(yeindex),ns,ng
+                    stop
+                 endif
+                 if (local_delta(ns,ng).lt.0.0d0) then
+                    write(*,"(a,1P4E18.9,i6,i6)") "delta < 0", &
+                         local_delta(ns,ng),eos_variables(rhoindex), &
+                         eos_variables(tempindex),eos_variables(yeindex),ns,ng
+                    stop
+                 endif
               enddo !do ng=1,mytable_number_groups
            enddo !do ns=1,number_output_species
 
@@ -330,10 +355,12 @@ program make_table_example
                  table_emission_node(displs(mpirank)+irho,itemp,iye,ns,ng) = local_emissivity(ns,ng) !ergs/cm^3/s/MeV/srad
                  table_absopacity_node(displs(mpirank)+irho,itemp,iye,ns,ng) = local_absopacity(ns,ng) !cm^-1
                  table_scatopacity_node(displs(mpirank)+irho,itemp,iye,ns,ng) = local_scatopacity(ns,ng) !cm^-1
+                 table_delta_node(displs(mpirank)+irho,itemp,iye,ns,ng) = local_delta(ns,ng) !dimensionless
 #else
                  table_emission(irho,itemp,iye,ns,ng) = local_emissivity(ns,ng) !ergs/cm^3/s/MeV/srad
                  table_absopacity(irho,itemp,iye,ns,ng) = local_absopacity(ns,ng) !cm^-1
                  table_scatopacity(irho,itemp,iye,ns,ng) = local_scatopacity(ns,ng) !cm^-1
+                 table_delta(irho,itemp,iye,ns,ng) = local_delta(ns,ng) !dimensionless
 #endif
               enddo !do ns=1,number_output_species
            enddo !do ng=1,mytable_number_groups
@@ -344,6 +371,7 @@ program make_table_example
      deallocate(local_emissivity)
      deallocate(local_absopacity)
      deallocate(local_scatopacity)
+     deallocate(local_delta)
      deallocate(eos_variables)
   enddo!do irho=1,final_table_size_rho
   !$OMP END PARALLEL DO! end do
@@ -359,6 +387,8 @@ program make_table_example
   call mpi_reduce(table_absopacity_node,table_absopacity,&
        table_size,mpi_double,mpi_sum,0,mpi_comm_world,ierror)
   call mpi_reduce(table_scatopacity_node,table_scatopacity,&
+       table_size,mpi_double,mpi_sum,0,mpi_comm_world,ierror)
+  call mpi_reduce(table_delta_node,table_delta,&
        table_size,mpi_double,mpi_sum,0,mpi_comm_world,ierror)
 
 
@@ -906,6 +936,14 @@ contains
     call h5sclose_f(dspace_id, error)  
     cerror = cerror + error   
 
+    call h5screate_simple_f(rank, dims5, dspace_id, error)
+    call h5dcreate_f(file_id, "scattering_delta", H5T_NATIVE_DOUBLE, &
+         dspace_id, dset_id, error)
+    call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE,table_delta, dims5, error)
+    call h5dclose_f(dset_id, error)
+    call h5sclose_f(dspace_id, error)  
+    cerror = cerror + error   
+    
     if (doing_inelastic.or.doing_epannihil) then
 
        rank = 1

--- a/src/make_table_example.F90
+++ b/src/make_table_example.F90
@@ -339,8 +339,8 @@ program make_table_example
                          eos_variables(tempindex),eos_variables(yeindex),ns,ng
                     stop
                  endif
-                 if (local_delta(ns,ng).lt.0.0d0) then
-                    write(*,"(a,1P4E18.9,i6,i6)") "delta < 0", &
+                 if (local_delta(ns,ng).lt.-1.0d0) then
+                    write(*,"(a,1P4E18.9,i6,i6)") "delta < -1", &
                          local_delta(ns,ng),eos_variables(rhoindex), &
                          eos_variables(tempindex),eos_variables(yeindex),ns,ng
                     stop

--- a/src/make_table_example.F90
+++ b/src/make_table_example.F90
@@ -936,13 +936,15 @@ contains
     call h5sclose_f(dspace_id, error)  
     cerror = cerror + error   
 
-    call h5screate_simple_f(rank, dims5, dspace_id, error)
-    call h5dcreate_f(file_id, "scattering_delta", H5T_NATIVE_DOUBLE, &
-         dspace_id, dset_id, error)
-    call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE,table_delta, dims5, error)
-    call h5dclose_f(dset_id, error)
-    call h5sclose_f(dspace_id, error)  
-    cerror = cerror + error   
+    if(.not. do_transport_opacities) then
+       call h5screate_simple_f(rank, dims5, dspace_id, error)
+       call h5dcreate_f(file_id, "scattering_delta", H5T_NATIVE_DOUBLE, &
+            dspace_id, dset_id, error)
+       call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE,table_delta, dims5, error)
+       call h5dclose_f(dset_id, error)
+       call h5sclose_f(dspace_id, error)
+       cerror = cerror + error
+    endif
     
     if (doing_inelastic.or.doing_epannihil) then
 

--- a/src/nulibtable.F90
+++ b/src/nulibtable.F90
@@ -57,12 +57,13 @@ end module nulibtable
 module nulibtable_interface
 
   interface
-     subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernels)
+     subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernels,include_scattering_delta)
        implicit none
 
        character(*) :: filename
        logical,optional :: include_Ielectron
        logical,optional :: include_epannihil_kernels
+       logical,optional :: include_scattering_delta
      end subroutine nulibtable_reader
   end interface
 

--- a/src/nulibtable.F90
+++ b/src/nulibtable.F90
@@ -21,6 +21,7 @@ module nulibtable
   real*8, allocatable,save :: nulibtable_emissivities(:,:,:,:)
   real*8, allocatable,save :: nulibtable_absopacity(:,:,:,:)
   real*8, allocatable,save :: nulibtable_scatopacity(:,:,:,:)
+  real*8, allocatable,save :: nulibtable_delta(:,:,:,:)
 
   real*8, allocatable,save :: nulibtable_Itable_Phi0(:,:,:)
   real*8, allocatable,save :: nulibtable_Itable_Phi1(:,:,:)
@@ -112,6 +113,14 @@ subroutine nulibtable_single_species_single_energy(xrho,xtemp,xye,lns,lng,eas,ea
 
   eas(:) = 10.0d0**eas(:)
 
+  if(eas_n1 == 4) then
+     call intp3d_many_mod(xlrho,xltemp,xye,eas(4), &
+          nulibtable_delta(:,:,:,startindex:endindex),nulibtable_nrho, &
+          nulibtable_ntemp,nulibtable_nye,1,nulibtable_logrho, &
+          nulibtable_logtemp,nulibtable_ye)
+  endif
+
+
 end subroutine nulibtable_single_species_single_energy
 
 !this takes rho,temp,ye,species and return eas over energy range
@@ -171,6 +180,15 @@ subroutine nulibtable_single_species_range_energy(xrho,xtemp,xye,lns,eas,eas_n1,
        nulibtable_logtemp,nulibtable_ye)
   
   eas(:,3) = 10.0d0**xeas(:)
+
+  if(eas_n2 == 4) then
+     xeas = 0.0d0
+     call intp3d_many_mod(xlrho,xltemp,xye,xeas, &
+          nulibtable_delta(:,:,:,startindex:endindex),nulibtable_nrho, &
+          nulibtable_ntemp,nulibtable_nye,eas_n1,nulibtable_logrho, &
+          nulibtable_logtemp,nulibtable_ye)
+     eas(:,4) = xeas(:)
+  endif
 
 end subroutine nulibtable_single_species_range_energy
 
@@ -243,6 +261,21 @@ subroutine nulibtable_range_species_range_energy(xrho,xtemp,xye,eas,eas_n1,eas_n
         eas(ins,ing,3) = 10.0d0**xeas(index)
      enddo
   enddo
+
+  if(eas_n3 == 4) then
+     xeas = 0.0d0
+     call intp3d_many_mod(xlrho,xltemp,xye,xeas,nulibtable_delta,nulibtable_nrho, &
+          nulibtable_ntemp,nulibtable_nye,eas_n1*eas_n2,nulibtable_logrho, &
+          nulibtable_logtemp,nulibtable_ye)
+
+     do ins=1,nulibtable_number_species
+        do ing=1,nulibtable_number_groups
+           index = (ins-1)*nulibtable_number_groups + (ing-1) + 1
+           eas(ins,ing,4) = xeas(index)
+        enddo
+     enddo
+
+  endif
 
 end subroutine nulibtable_range_species_range_energy
 

--- a/src/nulibtable_driver.F90
+++ b/src/nulibtable_driver.F90
@@ -18,7 +18,7 @@ program driver
   integer i,j,k,ns,ng,ngprime
   real*8 rho,temp,ye,mue,eta
 
-  call nulibtable_reader(filename,include_Ielectron=.true.,include_epannihil_kernels=.true.)
+  call nulibtable_reader(filename,include_Ielectron=.false.,include_epannihil_kernels=.false.,include_scattering_delta=.false.)
 
   allocate(eas(nulibtable_number_easvariables))
   allocate(eas_energy(nulibtable_number_groups,nulibtable_number_easvariables))

--- a/src/nulibtable_driver.F90
+++ b/src/nulibtable_driver.F90
@@ -50,7 +50,7 @@ program driver
      !example of single energy single species call, here I loop over rho
      write(*,*) "rho,temp,ye, eas variables"
      do i=1,100
-        eas(1:3) = 0.0d0
+        eas(:) = 0.0d0
         rho = 10.0d0**(8.0d0+6.0d0*dble(i)/100.0d0)
         temp = 1.0d0
         ye = 0.35d0

--- a/src/nulibtable_reader.F90
+++ b/src/nulibtable_reader.F90
@@ -3,7 +3,6 @@ subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernel
   
   use nulibtable
   use hdf5
-  use h5lt
   implicit none
 
   !inputs

--- a/src/nulibtable_reader.F90
+++ b/src/nulibtable_reader.F90
@@ -3,6 +3,7 @@ subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernel
   
   use nulibtable
   use hdf5
+  use h5lt
   implicit none
 
   !inputs
@@ -208,7 +209,23 @@ subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernel
      nulibtable_scatopacity(:,:,:,startindex:endindex) = log10(nulibtable_temp(:,:,:,i,:))
   enddo
 
-  nulibtable_number_easvariables = 3
+  call h5dopen_f(file_id, "scattering_delta", dset_id, error)
+  if(error==0) then
+     nulibtable_number_easvariables = 4
+     call h5dread_f(dset_id, H5T_NATIVE_DOUBLE,nulibtable_temp, dims5, error)
+     call h5dclose_f(dset_id, error)
+     cerror = cerror + error
+
+     allocate(nulibtable_delta(nulibtable_nrho,nulibtable_ntemp, &
+          nulibtable_nye,nulibtable_number_species*nulibtable_number_groups))
+     do i=1,nulibtable_number_species
+        startindex = (i-1)*nulibtable_number_groups+1
+        endindex = startindex + nulibtable_number_groups - 1
+        nulibtable_delta(:,:,:,startindex:endindex) = nulibtable_temp(:,:,:,i,:)
+     enddo
+  else
+     nulibtable_number_easvariables = 3
+  endif
 
   deallocate(nulibtable_temp)
 

--- a/src/nulibtable_reader.F90
+++ b/src/nulibtable_reader.F90
@@ -1,5 +1,5 @@
 !-*-f90-*-
-subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernels)
+subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernels,include_scattering_delta)
   
   use nulibtable
   use hdf5
@@ -10,9 +10,11 @@ subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernel
   character(*) :: filename
   logical,optional :: include_Ielectron
   logical,optional :: include_epannihil_kernels
+  logical,optional :: include_scattering_delta
   
   logical :: read_Ielectron
   logical :: read_epannihil
+  logical :: read_delta
   
   !H5 stuff
   integer :: error,rank,cerror
@@ -36,6 +38,12 @@ subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernel
      read_epannihil = include_epannihil_kernels
   else
      read_epannihil = .false.
+  endif
+
+  if (present(include_scattering_delta)) then
+     read_delta = include_scattering_delta
+  else
+     read_delta = .false.
   endif
 
   cerror = 0
@@ -209,9 +217,9 @@ subroutine nulibtable_reader(filename,include_Ielectron,include_epannihil_kernel
      nulibtable_scatopacity(:,:,:,startindex:endindex) = log10(nulibtable_temp(:,:,:,i,:))
   enddo
 
-  call h5dopen_f(file_id, "scattering_delta", dset_id, error)
-  if(error==0) then
+  if(read_delta) then
      nulibtable_number_easvariables = 4
+     call h5dopen_f(file_id, "scattering_delta", dset_id, error)
      call h5dread_f(dset_id, H5T_NATIVE_DOUBLE,nulibtable_temp, dims5, error)
      call h5dclose_f(dset_id, error)
      cerror = cerror + error

--- a/src/point_example.F90
+++ b/src/point_example.F90
@@ -38,6 +38,7 @@ program point_example
   real*8, allocatable,dimension(:,:) :: local_emissivity
   real*8, allocatable,dimension(:,:) :: local_absopacity
   real*8, allocatable,dimension(:,:) :: local_scatopacity
+  real*8, allocatable,dimension(:,:) :: local_delta
   real*8, allocatable,dimension(:,:) :: local_Phi0, local_Phi1
   real*8, allocatable,dimension(:,:) :: blackbody_spectra
   real*8, allocatable,dimension(:) :: eos_variables
@@ -52,6 +53,7 @@ program point_example
   allocate(local_emissivity(mypoint_number_output_species,mypoint_number_groups))
   allocate(local_absopacity(mypoint_number_output_species,mypoint_number_groups))
   allocate(local_scatopacity(mypoint_number_output_species,mypoint_number_groups))
+  allocate(local_delta(mypoint_number_output_species,mypoint_number_groups))
   allocate(blackbody_spectra(mypoint_number_output_species,mypoint_number_groups))
 
   call input_parser(parameters)
@@ -115,14 +117,15 @@ program point_example
   !balance and uses the opacities to fullying calculate the
   !emissivities and vice versa, see single_point_return_all.
   call single_point_return_all(eos_variables, &
-       local_emissivity,local_absopacity,local_scatopacity, &
+       local_emissivity,local_absopacity,local_scatopacity,local_delta, &
        mypoint_neutrino_scheme)
 
   write(*,*) "Example of a single point call with returning all emissivity, absorptive opacity, and scattering opacity"
   write(*,*) 
   do i=1,mypoint_number_output_species
      do j=1,mypoint_number_groups
-        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j),local_scatopacity(i,j)
+        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j), &
+             local_scatopacity(i,j),local_delta(i,j)
      enddo
   enddo
 
@@ -139,10 +142,12 @@ program point_example
   deallocate(local_emissivity)
   deallocate(local_absopacity)
   deallocate(local_scatopacity)
+  deallocate(local_delta)
   !allocate the arrays for the point values
   allocate(local_emissivity(mypoint_number_species,mypoint_number_groups))
   allocate(local_absopacity(mypoint_number_species,mypoint_number_groups))
   allocate(local_scatopacity(mypoint_number_species,mypoint_number_groups))
+  allocate(local_delta(mypoint_number_species,mypoint_number_groups))
 
   write(*,*) "Example of single point but only emissivity"
   write(*,*) 
@@ -154,11 +159,12 @@ program point_example
 
   write(*,*) "Example of single point but only scattering opacity"
   write(*,*) 
-  call return_scattering_opacity_spectra_given_neutrino_scheme(local_scatopacity,eos_variables)
+  call return_scattering_opacity_spectra_given_neutrino_scheme(local_scatopacity,local_delta,eos_variables)
 
   do i=1,mypoint_number_output_species
      do j=1,mypoint_number_groups
-        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j),local_scatopacity(i,j)
+        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j), &
+             local_scatopacity(i,j),local_delta(i,j)
      enddo
   enddo
 

--- a/src/point_example_with_HelmholtzEOS.F90
+++ b/src/point_example_with_HelmholtzEOS.F90
@@ -40,6 +40,7 @@ program point_example_with_HelmholtzEOS
   real*8, allocatable,dimension(:,:) :: local_emissivity
   real*8, allocatable,dimension(:,:) :: local_absopacity
   real*8, allocatable,dimension(:,:) :: local_scatopacity
+  real*8, allocatable,dimension(:,:) :: local_delta
   real*8, allocatable,dimension(:,:) :: local_Phi0, local_Phi1
   real*8, allocatable,dimension(:,:) :: blackbody_spectra
   real*8, allocatable,dimension(:) :: eos_variables
@@ -58,6 +59,7 @@ program point_example_with_HelmholtzEOS
   allocate(local_emissivity(mypoint_number_output_species,mypoint_number_groups))
   allocate(local_absopacity(mypoint_number_output_species,mypoint_number_groups))
   allocate(local_scatopacity(mypoint_number_output_species,mypoint_number_groups))
+  allocate(local_delta(mypoint_number_output_species,mypoint_number_groups))
   allocate(blackbody_spectra(mypoint_number_output_species,mypoint_number_groups))
 
   !this sets up many cooefficients and creates the energy grid (one
@@ -199,14 +201,15 @@ program point_example_with_HelmholtzEOS
   !balance and uses the opacities to fullying calculate the
   !emissivities and vice versa, see single_point_return_all.
   call single_point_return_all(eos_variables, &
-       local_emissivity,local_absopacity,local_scatopacity, &
+       local_emissivity,local_absopacity,local_scatopacity,local_delta, &
        mypoint_neutrino_scheme)
 
   write(*,*) "Example of a single point call with returning all emissivity, absorptive opacity, and scattering opacity"
   write(*,*) 
   do i=1,mypoint_number_output_species
      do j=1,mypoint_number_groups
-        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j),local_scatopacity(i,j)
+        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j), &
+             local_scatopacity(i,j),local_delta(i,j)
      enddo
   enddo
 
@@ -223,10 +226,12 @@ program point_example_with_HelmholtzEOS
   deallocate(local_emissivity)
   deallocate(local_absopacity)
   deallocate(local_scatopacity)
+  deallocate(local_delta)
   !allocate the arrays for the point values
   allocate(local_emissivity(mypoint_number_species,mypoint_number_groups))
   allocate(local_absopacity(mypoint_number_species,mypoint_number_groups))
   allocate(local_scatopacity(mypoint_number_species,mypoint_number_groups))
+  allocate(local_delta(mypoint_number_species,mypoint_number_groups))
 
   write(*,*) "Example of single point but only emissivity"
   write(*,*) 
@@ -238,11 +243,12 @@ program point_example_with_HelmholtzEOS
 
   write(*,*) "Example of single point but only scattering opacity"
   write(*,*) 
-  call return_scattering_opacity_spectra_given_neutrino_scheme(local_scatopacity,eos_variables)
+  call return_scattering_opacity_spectra_given_neutrino_scheme(local_scatopacity,local_delta,eos_variables)
 
   do i=1,mypoint_number_output_species
      do j=1,mypoint_number_groups
-        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j),local_scatopacity(i,j)
+        write(*,"(i4,i4,1P10E18.9)") i,j,energies(j),local_emissivity(i,j),local_absopacity(i,j), &
+             local_scatopacity(i,j),local_delta(i,j)
      enddo
   enddo
 

--- a/src/requested_interactions.inc
+++ b/src/requested_interactions.inc
@@ -7,6 +7,7 @@
   logical :: do_electronpolarization_correction = .true.
   logical :: do_nc_virial_correction = .false.
   logical :: do_strange_coupling = .false.
+  logical :: do_transport_opacities = .true.
   real*8, parameter :: gAs = -0.2d0 !dimensionless, for the strange coupling
 
   !absorptions

--- a/src/scattering.F90
+++ b/src/scattering.F90
@@ -52,7 +52,7 @@ subroutine nu_scatter_elastic_e_total(neutrino_energy,transport,lepton,eos_varia
   !endif
 
   ! check output
-  if(delta<0.0d0 .or. delta>1.0d0) then
+  if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
@@ -82,7 +82,7 @@ subroutine nu_scatter_elastic_alpha_total(neutrino_energy,transport,lepton,cross
   !end if
 
   ! check output
-  if(delta<0.0d0 .or. delta>1.0d0) then
+  if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
@@ -183,7 +183,7 @@ subroutine nu_scatter_elastic_p_total(neutrino_energy,transport,lepton,eos_varia
   endif
   
   ! check output
-  if(delta<0.0d0 .or. delta>1.0d0) then
+  if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
@@ -278,7 +278,7 @@ subroutine nu_scatter_elastic_n_total(neutrino_energy,transport,lepton,eos_varia
   endif
 
   ! check output
-  if(delta<0.0d0 .or. delta>1.0d0) then
+  if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
@@ -459,7 +459,7 @@ subroutine nu_scatter_elastic_heavy_total(neutrino_energy,transport,lepton,eos_v
   !endif
 
   ! check output
-  if(delta<0.0d0 .or. delta>1.0d0) then
+  if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
@@ -517,9 +517,9 @@ function nu_scatter_elastic_heavy_differential(neutrino_energy, &
      lepton_local = -1
   endif
 
-  if (transport.eq.0) then
-     stop "Sion correction is determined for transport differential cross section"
-  endif
+  !if (transport.eq.0) then
+  !   stop "Sion correction is determined for transport differential cross section"
+  !endif
 
   W = 1.0d0 - 2.0d0*eos_variables(zbarindex)/eos_variables(abarindex)*(1.0d0-2.0d0*sin2thetaW)
   
@@ -589,16 +589,23 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
   real*8 :: crosssection
   real*8 :: delta
   real*8 :: this_opacity
+  integer :: transport
   
   scattering_opacity = 0.0d0
   average_delta = 0.0d0
+
+  if(do_transport_opacities) then
+     transport = 1
+  else
+     transport = 0
+  endif
   
   !electron neutrino
   if (neutrino_species.eq.1) then
      !scattering (transport cross section) on neutrons
      if (add_nue_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = 1
-        call nu_scatter_elastic_n_total(neutrino_energy,1,1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_n_total(neutrino_energy,transport,1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity             
         average_delta      = average_delta      + this_opacity*delta
@@ -607,7 +614,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on protons
      if (add_nue_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = 1
-        call nu_scatter_elastic_p_total(neutrino_energy,1,1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_p_total(neutrino_energy,transport,1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -616,7 +623,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on heavies
      if (add_nue_scattering_heavies.and.eos_variables(xhindex).ne.0.0d0) then
         !function call takes neutrino energy, transport=1, lepton = 1
-        call nu_scatter_elastic_heavy_total(neutrino_energy,1,1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_heavy_total(neutrino_energy,transport,1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xhindex)/eos_variables(abarindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -625,7 +632,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section??) on electrons
      if (add_nue_scattering_electrons) then
         ! matter temperature, density, transport=1, lepton = 1
-        call nu_scatter_elastic_e_total(neutrino_energy,1,1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_e_total(neutrino_energy,transport,1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(yeindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -634,7 +641,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering on alpha
      if (add_nue_scattering_alphas) then
         ! matter temperature, density, transport=1, lepton = 1
-        call nu_scatter_elastic_alpha_total(neutrino_energy,1,1,crosssection,delta)
+        call nu_scatter_elastic_alpha_total(neutrino_energy,transport,1,crosssection,delta)
         this_opacity = crosssection * (eos_variables(xaindex)/4.0d0)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -645,7 +652,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on neutrons
      if (add_anue_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = -1
-        call nu_scatter_elastic_n_total(neutrino_energy,1,-1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_n_total(neutrino_energy,transport,-1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -654,7 +661,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on protons
      if (add_anue_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = -1
-        call nu_scatter_elastic_p_total(neutrino_energy,1,-1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_p_total(neutrino_energy,transport,-1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -663,7 +670,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on heavies
      if (add_anue_scattering_heavies.and.eos_variables(xhindex).ne.0.0d0) then
         !function call takes neutrino energy, transport=1, lepton = -1
-        call nu_scatter_elastic_heavy_total(neutrino_energy,1,-1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_heavy_total(neutrino_energy,transport,-1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xhindex)/eos_variables(abarindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -672,7 +679,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section??) on electrons
      if (add_anue_scattering_electrons) then
         ! matter temperature, density, transport=1, lepton = -1
-        call nu_scatter_elastic_e_total(neutrino_energy,1,-1,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_e_total(neutrino_energy,transport,-1,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(yeindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -681,7 +688,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering on alpha
      if (add_anue_scattering_alphas) then
         ! matter temperature, density, transport=1, lepton = -1
-        call nu_scatter_elastic_alpha_total(neutrino_energy,1,-1,crosssection,delta)
+        call nu_scatter_elastic_alpha_total(neutrino_energy,transport,-1,crosssection,delta)
         this_opacity = crosssection * (eos_variables(xaindex)/4.0d0)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -692,7 +699,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on neutrons
      if (add_numu_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = 2
-        call nu_scatter_elastic_n_total(neutrino_energy,1,2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_n_total(neutrino_energy,transport,2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -701,7 +708,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on protons
      if (add_numu_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = 2
-        call nu_scatter_elastic_p_total(neutrino_energy,1,2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_p_total(neutrino_energy,transport,2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -710,7 +717,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on heavies
      if (add_numu_scattering_heavies.and.eos_variables(xhindex).ne.0.0d0) then
         !function call takes neutrino energy, transport=1, lepton = 2
-        call nu_scatter_elastic_heavy_total(neutrino_energy,1,2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_heavy_total(neutrino_energy,transport,2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xhindex)/eos_variables(abarindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -719,7 +726,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section??) on electrons
      if (add_numu_scattering_electrons) then
         ! matter temperature, density, transport=1, lepton = 2
-        call nu_scatter_elastic_e_total(neutrino_energy,1,2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_e_total(neutrino_energy,transport,2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(yeindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -728,7 +735,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering on alpha
      if (add_numu_scattering_alphas) then
         ! matter temperature, density, transport=1, lepton = 2
-        call nu_scatter_elastic_alpha_total(neutrino_energy,1,2,crosssection,delta)
+        call nu_scatter_elastic_alpha_total(neutrino_energy,transport,2,crosssection,delta)
         this_opacity = crosssection * (eos_variables(xaindex)/4.0d0)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -739,7 +746,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on neutrons
      if (add_anumu_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = -2
-        call nu_scatter_elastic_n_total(neutrino_energy,1,-2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_n_total(neutrino_energy,transport,-2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -748,7 +755,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on protons
      if (add_anumu_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = -2
-        call nu_scatter_elastic_p_total(neutrino_energy,1,-2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_p_total(neutrino_energy,transport,-2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -757,7 +764,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on heavies
      if (add_anumu_scattering_heavies.and.eos_variables(xhindex).ne.0.0d0) then
         !function call takes neutrino energy, transport=1, lepton = -2
-        call nu_scatter_elastic_heavy_total(neutrino_energy,1,-2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_heavy_total(neutrino_energy,transport,-2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xhindex)/eos_variables(abarindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -766,7 +773,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section??) on electrons
      if (add_anumu_scattering_electrons) then
         ! matter temperature, density, transport=1, lepton = -2
-        call nu_scatter_elastic_e_total(neutrino_energy,1,-2,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_e_total(neutrino_energy,transport,-2,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(yeindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -775,7 +782,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering on alpha
      if (add_anumu_scattering_alphas) then
         ! matter temperature, density, transport=1, lepton = -2
-        call nu_scatter_elastic_alpha_total(neutrino_energy,1,-2,crosssection,delta)
+        call nu_scatter_elastic_alpha_total(neutrino_energy,transport,-2,crosssection,delta)
         this_opacity = crosssection * (eos_variables(xaindex)/4.0d0)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -786,7 +793,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on neutrons
      if (add_nutau_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = 3
-        call nu_scatter_elastic_n_total(neutrino_energy,1,3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_n_total(neutrino_energy,transport,3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -795,7 +802,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on protons
      if (add_nutau_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = 3
-        call nu_scatter_elastic_p_total(neutrino_energy,1,3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_p_total(neutrino_energy,transport,3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -804,7 +811,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on heavies
      if (add_nutau_scattering_heavies.and.eos_variables(xhindex).ne.0.0d0) then
         !function call takes neutrino energy, transport=1, lepton = 3
-        call nu_scatter_elastic_heavy_total(neutrino_energy,1,3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_heavy_total(neutrino_energy,transport,3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xhindex)/eos_variables(abarindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -813,7 +820,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section??) on electrons
      if (add_nutau_scattering_electrons) then
         ! matter temperature, density, transport=1, lepton = 3
-        call nu_scatter_elastic_e_total(neutrino_energy,1,3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_e_total(neutrino_energy,transport,3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(yeindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -822,7 +829,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering on alpha
      if (add_nutau_scattering_alphas) then
         ! matter temperature, density, transport=1, lepton = 3
-        call nu_scatter_elastic_alpha_total(neutrino_energy,1,3,crosssection,delta)
+        call nu_scatter_elastic_alpha_total(neutrino_energy,transport,3,crosssection,delta)
         this_opacity = crosssection * (eos_variables(xaindex)/4.0d0)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -833,7 +840,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on neutrons
      if (add_anutau_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = -3
-        call nu_scatter_elastic_n_total(neutrino_energy,1,-3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_n_total(neutrino_energy,transport,-3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -842,7 +849,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on protons
      if (add_anutau_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = -3
-        call nu_scatter_elastic_p_total(neutrino_energy,1,-3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_p_total(neutrino_energy,transport,-3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -851,7 +858,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section) on heavies
      if (add_anutau_scattering_heavies.and.eos_variables(xhindex).ne.0.0d0) then
         !function call takes neutrino energy, transport=1, lepton = -3
-        call nu_scatter_elastic_heavy_total(neutrino_energy,1,-3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_heavy_total(neutrino_energy,transport,-3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(xhindex)/eos_variables(abarindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -860,7 +867,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering (transport cross section??) on electrons
      if (add_anutau_scattering_electrons) then
         ! matter temperature, density, transport=1, lepton = -3
-        call nu_scatter_elastic_e_total(neutrino_energy,1,-3,eos_variables,crosssection,delta)
+        call nu_scatter_elastic_e_total(neutrino_energy,transport,-3,eos_variables,crosssection,delta)
         this_opacity = crosssection * eos_variables(yeindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -869,7 +876,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      !scattering on alpha
      if (add_anutau_scattering_alphas) then
         ! matter temperature, density, transport=1, lepton = -3
-        call nu_scatter_elastic_alpha_total(neutrino_energy,1,-3,crosssection,delta)
+        call nu_scatter_elastic_alpha_total(neutrino_energy,transport,-3,crosssection,delta)
         this_opacity = crosssection * (eos_variables(xaindex)/4.0d0)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
@@ -881,7 +888,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
   average_delta = average_delta / scattering_opacity   
 
   ! check output
-  if(average_delta<0.0d0 .or. average_delta>1.0d0) then
+  if(average_delta<-1.0d0 .or. average_delta>1.0d0) then
      write(*,*) "Invalid value of average delta: ",average_delta
      stop
   endif

--- a/src/scattering.F90
+++ b/src/scattering.F90
@@ -51,11 +51,13 @@ subroutine nu_scatter_elastic_e_total(neutrino_energy,transport,lepton,eos_varia
   !   stop "no transport crosssection?"
   !endif
 
+#ifdef DEBUG
   ! check output
   if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
+#endif
      
 end subroutine nu_scatter_elastic_e_total
 
@@ -81,11 +83,13 @@ subroutine nu_scatter_elastic_alpha_total(neutrino_energy,transport,lepton,cross
   delta = 0
   !end if
 
+#ifdef DEBUG
   ! check output
   if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
+#endif
   
 end subroutine nu_scatter_elastic_alpha_total
 
@@ -181,12 +185,14 @@ subroutine nu_scatter_elastic_p_total(neutrino_energy,transport,lepton,eos_varia
      crosssection = crosssection*weak_mag !implicit integration over \Omega
      delta = delta_p
   endif
-  
+
+#ifdef DEBUG
   ! check output
   if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
+#endif
 
 end subroutine nu_scatter_elastic_p_total
 
@@ -277,11 +283,13 @@ subroutine nu_scatter_elastic_n_total(neutrino_energy,transport,lepton,eos_varia
      delta = delta_n
   endif
 
+#ifdef DEBUG
   ! check output
   if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
+#endif
 
 end subroutine nu_scatter_elastic_n_total
 
@@ -458,11 +466,13 @@ subroutine nu_scatter_elastic_heavy_total(neutrino_energy,transport,lepton,eos_v
   !   stop "crossection assumes transport (i.e. (1.0d0-cosine) term)"
   !endif
 
+#ifdef DEBUG
   ! check output
   if(delta<-1.0d0 .or. delta>1.0d0) then
      write(*,*) "Invalid value of delta: ",delta
      stop
   endif
+#endif
 
 end subroutine nu_scatter_elastic_heavy_total
   
@@ -887,11 +897,13 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
   endif
   average_delta = average_delta / scattering_opacity   
 
+#ifdef DEBUG
   ! check output
   if(average_delta<-1.0d0 .or. average_delta>1.0d0) then
      write(*,*) "Invalid value of average delta: ",average_delta
      stop
   endif
+#endif
 
 end subroutine total_scattering_opacity
 

--- a/src/scattering.F90
+++ b/src/scattering.F90
@@ -77,11 +77,12 @@ subroutine nu_scatter_elastic_alpha_total(neutrino_energy,transport,lepton,cross
   
   crosssection = 4.0d0*sigma0*(neutrino_energy/m_e)**2*sin2thetaW**2
 
-  !ONLY TRANSPORT OPACITY IMPLEMENTED
-  !if (transport.eq.1) then
-  crosssection = 2.0d0/3.0d0*crosssection
-  delta = 0
-  !end if
+  if (transport.eq.1) then
+     crosssection = 2.0d0/3.0d0*crosssection
+     delta = 0.0d0
+  else if (transport.eq.0) then
+     delta = 1.0d0
+  end if
 
 #ifdef DEBUG
   ! check output
@@ -459,12 +460,14 @@ subroutine nu_scatter_elastic_heavy_total(neutrino_energy,transport,lepton,eos_v
   !integrate over phi
   crosssection = 2.0d0*pi*crosssection
   
-  !ONLY TRANSPORT OPACITY IMPLEMENTED
-  !if (transport.eq.1) then
-  delta = 0
-  !else if (transport.eq.0) then
-  !   stop "crossection assumes transport (i.e. (1.0d0-cosine) term)"
-  !endif
+  if (transport.eq.1) then
+     delta = 0.0
+  else if (transport.eq.0) then
+     !NOTE - ion-ion correlation corrections were determined for transport opacity.
+     !       converting to a regular opacity this way is not quite correct, but probably fine
+     crosssection = 1.5d0 * crosssection
+     delta = 1.0
+  endif
 
 #ifdef DEBUG
   ! check output


### PR DESCRIPTION
added delta output to scattering opacity subroutines. Extra work is done, but no change in outcome yet. Differential cross section functions could probably be simplified further. Suppressed errors when non-transport opacities are requested and not implemented - just give transport opacities with delta=0. renamed type to transport in several routines for consistency.