### PR TITLE
beta decay

### DIFF
--- a/README
+++ b/README
@@ -191,6 +191,7 @@ following publications from which the weak-rate tables derive:
 | http://prl.aps.org/abstract/PRL/v90/i24/e241102                              |
 --------------------------------------------------------------------------------
 
+Tables are available from: https://groups.nscl.msu.edu/charge_exchange/weakrates.html
 
 Sample Executables:
 -------------------
@@ -315,7 +316,8 @@ Extras
 
 There is support in NuLib for using Matthias Hempel's NSE mass
 distributions available from
-http://phys-merger.physik.unibas.ch/~hempel/eos.html.  To enable these
+https://astro.physik.unibas.ch/people/matthias-hempel/equations-of-state.html
+To enable these
 use must download his code and tables from his website, place them in
 the directory src/extra_code_and_tables/ and enable the preprocessor
 flag NUCLEI_HEMPEL.  We use the SFHo table as an example in the code,
@@ -324,7 +326,7 @@ directly.  Please see this file for more details.
 
 A few small changes must be made to xxxx_xxxx_composition_module.f
 as provided by M. Hempel if the weak_rates module (electron-capture
-rates).Primarily a public (non-private) copy of the loaded nuclear
+rates). Primarily a public (non-private) copy of the loaded nuclear
 masses must be exposed. e.g. for the SFHo EOS, one must add the
 following to the source file:
 ---------------------------------------------------
@@ -333,4 +335,5 @@ following to the source file:
 | sfho_mass = mass                                |
 ---------------------------------------------------
 We also found that an updated path is needed for the
-composition binary included with the module.
+composition binary included with the module (or a symbolic link
+from the run directory).

--- a/src/emissivities.F90
+++ b/src/emissivities.F90
@@ -406,7 +406,6 @@ subroutine return_emissivity_spectra_given_neutrino_scheme(emissivity_spectra,eo
            emissivity_spectra(ns,:) = emissivity_spectra(ns,:) + ec_emissivity(:) !erg/cm^3/s/MeV/srad
         end if
         if (add_anue_emission_weakinteraction_poscap.and.ns.eq.2) then
-           stop "emissivities :: anue weak rates are not yet implemented"
            call microphysical_electron_capture(ns,eos_variables,ec_emissivity)
            emissivity_spectra(ns,:) = emissivity_spectra(ns,:) + ec_emissivity(:) !erg/cm^3/s/MeV/srad
         end if

--- a/src/requested_interactions.inc
+++ b/src/requested_interactions.inc
@@ -72,7 +72,7 @@
   logical :: add_anutau_emission_NNBrems = .true.	
 
   logical :: add_nue_emission_weakinteraction_ecap = .true.
-  logical :: add_anue_emission_weakinteraction_poscap = .false.
+  logical :: add_anue_emission_weakinteraction_poscap = .true.
 
   logical :: apply_kirchoff_to_pair_creation = .true.
 

--- a/src/weakrates/interface.F90
+++ b/src/weakrates/interface.F90
@@ -98,12 +98,10 @@ contains
           avgenergy(1) = rnu/(rcap + rbeta) 
           avgenergy(2) = qec_eff !necessary to fulfill the first comparison in qec_solver
        else if (neutrino_species.eq.2) then
-          stop "Positron capture effective q is bugged and not currently working,&
-               please turn it off in requested_interactions.inc."
-          rbeta = return_weakrate(weakratelib,A,Z,t9,lrhoYe,idxtable,4)
-          rcap = return_weakrate(weakratelib,A,Z,t9,lrhoYe,idxtable,5)
-          rnu = return_weakrate(weakratelib,A,Z,t9,lrhoYe,idxtable,6)         
-          qec_eff = -weakratelib%tables(idxtable)%nuclear_species(weakratelib%tables(idxtable)%nucleus_index(A,Z),1) 
+          rbeta = return_weakrate(weakratelib,A,Z+1,t9,lrhoYe,idxtable,4)
+          rcap = return_weakrate(weakratelib,A,Z+1,t9,lrhoYe,idxtable,5)
+          rnu = return_weakrate(weakratelib,A,Z+1,t9,lrhoYe,idxtable,6)         
+          qec_eff = -weakratelib%tables(idxtable)%nuclear_species(weakratelib%tables(idxtable)%nucleus_index(A,Z+1),1) 
           avgenergy(1) = rnu/(rcap + rbeta)   
           avgenergy(2) = qec_eff
        else
@@ -139,7 +137,8 @@ contains
        end if
     else if (neutrino_species.eq.2) then
        if (approx_rate_flag) then
-          stop "There is currently no approximate rate for positron capture"
+          !approximation doesn't work for antineutrinos
+          normalization_constant = 0.0
        else
           normalization_constant = (rbeta+rcap)/spectra
        end if
@@ -436,7 +435,7 @@ contains
     
     do i=1,weakratelib%approx%nspecies 
 
-       if(weakratelib%approx%number_densities(i).eq.0.0d0)cycle
+       if(weakratelib%approx%number_densities(i).eq.0.0d0) cycle
 
        A = weakratelib%approx%nuclei_A(i)
        Z = weakratelib%approx%nuclei_Z(i)
@@ -445,7 +444,8 @@ contains
        !use the parameterized rate function, else skip this nucleus
        ! check if rate exists in a table
        if (weakratelib%ntables.ne.0)then
-          idxtable = in_table(weakratelib,A,Z,logrhoYe,t9)
+          if (neutrino_species .eq. 1) idxtable = in_table(weakratelib,A,Z,logrhoYe,t9)
+          if (neutrino_species .eq. 2) idxtable = in_table(weakratelib,A,Z+1,logrhoYe,t9)
        endif
 
        ! if no table contains the requested rate

--- a/src/weakrates/interface.F90
+++ b/src/weakrates/interface.F90
@@ -100,8 +100,8 @@ contains
        else if (neutrino_species.eq.2) then
           rbeta = return_weakrate(weakratelib,A,Z+1,t9,lrhoYe,idxtable,4)
           rcap = return_weakrate(weakratelib,A,Z+1,t9,lrhoYe,idxtable,5)
-          rnu = return_weakrate(weakratelib,A,Z+1,t9,lrhoYe,idxtable,6)         
-          qec_eff = -weakratelib%tables(idxtable)%nuclear_species(weakratelib%tables(idxtable)%nucleus_index(A,Z+1),1) 
+          rnu = return_weakrate(weakratelib,A,Z+1,t9,lrhoYe,idxtable,6)
+          qec_eff = -weakratelib%tables(idxtable)%nuclear_species(weakratelib%tables(idxtable)%nucleus_index(A,Z+1),1)
           avgenergy(1) = rnu/(rcap + rbeta)   
           avgenergy(2) = qec_eff
        else


### PR DESCRIPTION
This PR includes some small updates in order to make beta decays (e-) and positron captures work in the NuLib weakrates library.  Wright et al. updated NuLib to include antineutrino from weak interactions and these changes are taken from their work.  

Previously, the infrastructure was in place but it halted upon usage.  There were a few changes required to make it consistent.  First, when looking if a rate exists for a Z,A nucleus, we must look for the Z+1,A electron capture rate entry, that is where the 'negative' direction data is stored.  Also when interpolating the rate we must look there too.  Note, the approximation is not working the beta decay direction.  Changes will be needed for that.