### PR TITLE
Final state blocking

### DIFF
--- a/scripts/make_grey_table.py
+++ b/scripts/make_grey_table.py
@@ -1,0 +1,295 @@
+import numpy as np
+from scipy import integrate
+from scipy import interpolate
+import h5py
+
+def save_table_as_hf5f(table: dict, table_name: str = "table.h5") -> None:
+    """
+    Saves a table of data to an HDF5 file.
+
+    This function iterates over the keys in a dictionary, saving each
+    numpy array to an HDF5 file. The arrays are transposed before saving to match the
+    expected layout in the HDF5 file format. 
+
+    Parameters:
+    - table (dict): The table to save, as a python dict. Each key will be saved as a hdf5 dataset.
+    - table_name (str, optional): The name of the HDF5 file to save the data to. Defaults to "table.h5".
+
+    Returns:
+    - None: This function does not return a value but saves the data to an HDF5 file.
+    """
+    # Open or create the HDF5 file for writing
+    hf = h5py.File(table_name, 'w')
+    # Iterate over each key-value pair in the table dictionary
+    for key in table.keys():
+        # Create a dataset for each key in the HDF5 file and save the transposed numpy array
+        hf.create_dataset(key, data=table[key].T)
+    # Close the HDF5 file to ensure data is written properly and resources are freed
+    hf.close()
+
+
+
+def read_nulib_table(fil: str) -> dict:
+    """
+    Reads data from a NuLib table file and organizes it into a dictionary.
+
+    This function opens a NuLib table file, reads
+    temperature, density, electron fraction, scattering
+    opacity, absorption opacity, neutrino energies, emissivities, and bin widths.
+ 
+    Parameters:
+    - fil (str): The file path to the NuLib table file, typically an HDF5 file.
+
+    Returns:
+    - dict: A dictionary containing arrays of neutrino energies, densities (rho),
+      temperatures (temp), electron fractions (ye), scattering opacities,
+      absorption opacities, emissivities, and bin widths. T
+
+    The returned dictionary keys are: "energy", "rho", "temp", "ye", "scatter",
+    "absorption", "emissivities", and "bin_width", each mapping to the corresponding
+    numpy array extracted from the NuLib table file.
+    """
+
+    table = h5py.File(fil, 'r') 
+    nulib_temp = np.asarray(table["temp_points"])
+    nulib_rho = np.asarray(table["rho_points"])
+    nulib_ye = np.asarray(table["ye_points"])
+    scatter = np.asarray(table["scattering_opacity"])
+    abso = np.asarray(table["absorption_opacity"])
+    energy_bins = np.array(table["neutrino_energies"]) 
+    emiss = np.asarray(table['emissivities'])
+    bw = np.asarray(table['bin_widths'])
+
+    nulib_table = {"energy" : energy_bins, "rho" : nulib_rho, "temp" : nulib_temp, "ye" : nulib_ye,
+                   "scatter" : scatter, "absorption" : abso, "emissivities" : emiss, 'bin_width' : bw }
+
+    return nulib_table
+
+
+
+def read_eos_table(fil: str) -> dict:
+    """
+    Reads data from an EOS table file and organizes it into a dictionary.
+
+    This function opens an EOS table file and extracts the 
+    chemical potential density, temperature, and electron fraction.
+    The chemical potentials are adjusted to represent the total muon chemical potential.
+
+    Parameters:
+    - fil (str): The file path to the EOS table file, typically an HDF5 file.
+
+    Returns:
+    - dict: A dictionary containing arrays for chemical potential ("mu"),
+      log-scaled densities ("log_rho"), log-scaled temperatures ("log_temp"), and electron
+      fractions ("ye").
+
+    #IMPORTANT: This function is written for specific EOS tables. You might have to change it.
+    """
+
+
+    eosfile = h5py.File(fil, 'r')
+    eos_mu = np.asarray(eosfile["mu_e"]) - np.asarray(eosfile["mu_n"]) + np.asarray(eosfile["mu_p"])
+    eos_logden = np.asarray(eosfile["logrho"])
+    eos_logtemp = np.asarray(eosfile["logtemp"])
+    eos_ye = np.asarray(eosfile["ye"])
+
+    eos_table = {"mu" : eos_mu, "log_rho" : eos_logden, "log_temp" : eos_logtemp, "ye" : eos_ye}
+    return eos_table
+
+
+def integrate_table(nulib_table: dict, eos_table: dict) -> np.ndarray:
+    """
+    Integrates neutrino interaction data over energy to compute interaction rates.
+    
+    This function calculates the neutrino absorption, emission, and scattering rates over a range of conditions
+    specified by the NuLib and EOS tables. It is assumed that neutrinos follow a Fermi-Dirac distribution, and
+    the energy dependence of the interaction rates is integrated out using the temperature data provided in the
+    nulib_table.
+    
+    Parameters:
+    - nulib_table (dict): Contains neutrino interaction data from the NuLib table, including neutrino energies,
+      densities ("rho"), temperatures ("temp"), electron fractions ("ye"), scattering and absorption opacities.
+    - eos_table (dict): Contains state of matter data from the EOS table, including chemical potentials ("mu"),
+      log-scaled densities ("log_rho"), log-scaled temperatures ("log_temp"), and electron fractions ("ye").
+    
+    Returns:
+    - np.ndarray: A multidimensional array containing integrated values for absorption, emission, and scattering rates,
+      structured as [neutrino species, interaction type, density, temperature, electron fraction].
+    
+    Notes:
+    - This function calculate the rates under the asumption that the neutrinos have the same temperature as the fluid.
+    """
+    # Factors to adjust the energy terms for different neutrino species
+    mfac = np.array([1.0, -1.0, 0.0])
+    # Coefficients for the distribution calculations
+    fac = np.array([1.0, 1.0, 4.0])
+    # Initialize the output array with zeros
+    table = np.zeros([3, 4, len(nulib_table["rho"]), len(nulib_table["temp"]), len(nulib_table["ye"])])
+    # Points for EOS interpolation
+    points = (eos_table["ye"], eos_table["log_temp"], eos_table["log_rho"])
+    # Neutrino energy array
+    energy = np.array(nulib_table["energy"])
+
+    # Generate meshgrids for interpolation
+    xv, yv, zv = np.meshgrid(nulib_table["ye"], np.log10(nulib_table["temp"]), np.log10(nulib_table["rho"]), indexing="ij")
+    # Interpolate the chemical potentials from the EOS table
+    m1 = interpolate.interpn(points, eos_table["mu"], (xv, yv, zv))
+
+    for n in range(0, 3):  # Loop over neutrino species
+        # Calculate the eta factor for the Fermi-Dirac distribution
+        eta = (energy[:, None, None, None] - mfac[n] * m1) / nulib_table["temp"][None, None, :, None]
+        # Compute the distribution for neutrino interactions
+        bb = fac[n] / (1.0 + np.exp(eta)) * (energy[:, None, None, None]) ** 3
+        # Integrate over energy to get baseline interaction rates
+        bb_int = np.trapz(bb, x=energy, axis=0)
+        
+        # Absorption calculations
+        absorption = bb * nulib_table["absorption"][:, n, :, :, :]
+        absorption_int = np.trapz(absorption, x=energy, axis=0)
+        table[n, 0, :, :, :] = absorption_int.T
+        # Normalized absorption rates
+        table[n, 1, :, :, :] = np.divide(absorption_int, bb_int, out=np.zeros_like(absorption_int), where=bb_int != 0).T
+
+        # Emission rate calculations
+        emiss = np.zeros_like(absorption)
+        for i in range(len(energy)):
+            emiss[i, :, :, :] = absorption[i, :, :, :] / energy[i]
+        emiss_int = np.trapz(emiss, x=energy, axis=0)
+        table[n, 3, :, :, :] = emiss_int.T
+
+        # Scattering rate calculations
+        scatter = bb * nulib_table["scatter"][:, n, :, :, :]
+        scatter_int = np.trapz(scatter, x=energy, axis=0)
+        table[n, 2, :, :, :] = np.divide(scatter_int, bb_int, out=np.zeros_like(scatter_int), where=bb_int != 0).T
+
+    return table
+
+
+
+def integrate_table_n_temp(nulib_table: dict, eos_table: dict, ntemp) -> np.ndarray:
+    """
+    Integrates neutrino interaction data over energy to compute interaction rates for a given neutrino temperature.
+    
+    This function calculates the neutrino absorption, emission, and scattering rates across a range of conditions,
+    assuming the neutrinos follow a Fermi-Dirac distribution. The energy dependence of the rates is integrated out
+    using the specified neutrino temperature, ntemp.
+    
+    Parameters:
+    - nulib_table (dict): Contains neutrino interaction data from the NuLib table, including energies, densities ("rho"),
+      temperatures ("temp"), electron fractions ("ye"), and opacities.
+    - eos_table (dict): Contains state of matter data from the EOS table, including chemical potentials ("mu"),
+      log-scaled densities ("log_rho"), log-scaled temperatures ("log_temp"), and electron fractions ("ye").
+    - ntemp (float): The neutrino temperature used to compute the Fermi-Dirac distribution.
+    
+    Returns:
+    - np.ndarray: A multidimensional array containing integrated values for absorption, emission, and scattering rates,
+      structured as [neutrino species, interaction type, density, temperature, electron fraction].
+
+    Notes:
+    - Unlike integrate_table(), this function allows for a neutrino temperature which differs from the fluid temperature.
+    """
+    # Multiplicative factors for energy adjustments based on neutrino species
+    mfac = np.array([1.0, -1.0, 0.0])
+    # Factors for the Fermi-Dirac distribution
+    fac = np.array([1.0, 1.0, 4.0])
+    # Initialize the output table with zeros
+    table = np.zeros([3, 4, len(nulib_table["rho"]), len(nulib_table["temp"]), len(nulib_table["ye"])])
+    # Reference points for EOS interpolation
+    points = (eos_table["ye"], eos_table["log_temp"], eos_table["log_rho"])
+    # Neutrino energy array
+    energy = np.array(nulib_table["energy"])
+    
+    # Create meshgrids for interpolation
+    xv, yv, zv = np.meshgrid(nulib_table["ye"], np.log10(nulib_table["temp"]), np.log10(nulib_table["rho"]), indexing="ij")
+    # Interpolate chemical potentials from the EOS table
+    m1 = interpolate.interpn(points, eos_table["mu"], (xv, yv, zv))
+
+    for n in range(0, 3):
+        # Compute the Fermi-Dirac distribution eta factor
+        eta = (energy[:, None, None, None] - mfac[n] * m1) / ntemp
+        # Calculate the distribution for neutrino interactions
+        bb = fac[n] / (1.0 + np.exp(eta)) * (energy[:, None, None, None]) ** 3
+        # Integrate over energy to get the baseline interaction rates
+        bb_int = np.trapz(bb, x=energy, axis=0)
+        
+        # Calculate absorption rates
+        absorption = bb * nulib_table["absorption"][:, n, :, :, :]
+        absorption_int = np.trapz(absorption, x=energy, axis=0)
+        table[n, 0, :, :, :] = absorption_int.T
+        table[n, 1, :, :, :] = np.divide(absorption_int, bb_int, out=np.zeros_like(absorption_int), where=bb_int != 0).T
+
+        # Calculate emission rates
+        emiss = np.zeros_like(absorption)
+        for i in range(len(energy)):
+            emiss[i, :, :, :] = absorption[i, :, :, :] / energy[i]
+        emiss_int = np.trapz(emiss, x=energy, axis=0)
+        table[n, 3, :, :, :] = emiss_int.T
+
+        # Calculate scattering rates
+        scatter = bb * nulib_table["scatter"][:, n, :, :, :]
+        scatter_int = np.trapz(scatter, x=energy, axis=0)
+        table[n, 2, :, :, :] = np.divide(scatter_int, bb_int, out=np.zeros_like(scatter_int), where=bb_int != 0).T
+
+    return table
+
+
+def generate_and_save_table(nulib_file: str,eos_file: str,output_file: str,
+                            num_temperatures: int = 12,temperature_range: tuple = (0.1, 16)) -> None:
+    """
+    Generates a 4D table for grey neutrino interactions over a range of temperatures and saves it to an HDF5 file.
+    The table integrates neutrino interaction data (absorption, emission, and scattering rates) over energy, 
+    assuming neutrinos follow a Fermi-Dirac distribution. It consists of two parts:
+    
+    1. Equilibrium interactions: Assumes the fluid temperature and the neutrino temperature are the same. 
+    
+    2. Non-equilibrium interactions: Allows for a range of neutrino temperatures, distinct from the fluid temperature. 
+       This section is generated by sampling over specified neutrino temperatures, determined by num_temperatures 
+       and temperature_range, to account for scenarios where neutrino and fluid temperatures differ.
+    
+
+    Parameters:
+    - nulib_file (str): Path to the NuLib table file.
+    - eos_file (str): Path to the EOS table file.
+    - output_file (str): Path and filename for the output HDF5 file.
+    - num_temperatures (int): Number of temperature points to generate.
+    - temperature_range (tuple): The minimum and maximum temperatures (in MeV) for the logspace generation.
+
+    Returns:
+    - None: The function does not return a value but writes data to an HDF5 file.
+    """
+    # Read NuLib and EOS tables
+    nulib_table = read_nulib_table(nulib_file)
+    eos_table = read_eos_table(eos_file)
+
+    # Generate log-spaced neutrino temperature array
+    log_temperatures = np.logspace(np.log10(temperature_range[0]), np.log10(temperature_range[1]), num=num_temperatures)
+
+    # Initialize the 4D table array
+    table4d = np.zeros([3, 4, len(nulib_table['rho']),len(nulib_table['temp']), len(nulib_table['ye']), len(log_temperatures)])
+
+    # Integrate over temperatures
+    tv4 = integrate_table(nulib_table, eos_table)  # Assuming integrate_table_v4 is similar to integrate_table
+    for i, tt in enumerate(log_temperatures):
+        table4d[:, :, :, :, :, i] = integrate_table_n_temp(nulib_table, eos_table, tt)
+        #The emissivities are always the ones "of the fluid". 
+        #It is done in this double counting way because it is easier down the line.
+        #Change this if you worry about the size of your table.
+        table4d[:, 0, :, :, :, i] = tv4[:, 0, :, :, :] 
+        table4d[:, 3, :, :, :, i] = tv4[:, 3, :, :, :]
+
+    # Construct the table dictionary
+    table_dict = {
+        "rho": nulib_table['rho'], "temp": nulib_table["temp"], "ye": nulib_table["ye"],
+        "tnue": log_temperatures,
+        "emissivities_eq": tv4[:, 0, :, :, :], "absorption_opacity_eq": tv4[:, 1, :, :, :],
+        "scattering_opacity_eq": tv4[:, 2, :, :, :], "number_emissivities_eq": tv4[:, 3, :, :, :],
+        "emissivities": table4d[:, 0, :, :, :, :], "absorption_opacity": table4d[:, 1, :, :, :, :],
+        "scattering_opacity": table4d[:, 2, :, :, :, :], "number_emissivities": table4d[:, 3, :, :, :, :]
+    }
+
+    # Save the table to an HDF5 file
+    save_table_as_hf5f(table_dict, table_name=output_file)
+
+
+#Example use
+#generate_and_save_table(nulib_file = 'NuLib_SRO_0.95.h5', eos_file = 'SRO.h5',output_path = 'NuLib_SRO_0.95_grey.h5')

--- a/src/absorption_crosssections.F90
+++ b/src/absorption_crosssections.F90
@@ -363,7 +363,7 @@ subroutine total_absorption_opacities(neutrino_species,neutrino_energy,absorptio
 
   !final state nucleon blocking
   !some low density, low temperature regions give issues with nucleon blocking, so if rho<1e11, assume no nulceon blocking
-  if (do_breunn_final_state_nucleon_blocking.and.eos_variables(rhoindex).ge.1.0d11) then
+  if (do_breunn_final_state_nucleon_blocking_abs.and.eos_variables(rhoindex).ge.1.0d11) then
      !final state neutron blocking, C14
      eta_np = neutron_number_density* &! # neutons/cm^3
           max(0.0d0,(proton_number_density/neutron_number_density-1.0d0)/ & !final state proton blocking, =1 if blocking is irrelevant

--- a/src/absorption_crosssections.F90
+++ b/src/absorption_crosssections.F90
@@ -333,7 +333,9 @@ subroutine total_absorption_opacities(neutrino_species,neutrino_energy,absorptio
                           !(mun+mn-mn)-(mup+mn-mp) = mun-mup-Delta_np
   real*8 :: mu_nu_eq !neutrino equilibrium chemical potential
   real*8 :: expterm,inverse_bottom !to calculate stimulated absorption
+  real*8 :: eta_pn, eta_np ! terms for final state blocking
 
+  
   !function declarations
   real*8 :: fermidirac !function declaration
   real*8 :: fermidirac_exptermonly !function declaration

--- a/src/absorption_crosssections.F90
+++ b/src/absorption_crosssections.F90
@@ -359,21 +359,30 @@ subroutine total_absorption_opacities(neutrino_species,neutrino_energy,absorptio
   matter_muhat0 = eos_variables(muhatindex) - delta_np 
   absorption_opacity = 0.0d0
 
+  !final state nucleon blocking
+  !some low density, low temperature regions give issues with nucleon blocking, so if rho<1e11, assume no nulceon blocking
+  if (do_breunn_final_state_nucleon_blocking.and.eos_variables(rhoindex).ge.1.0d11) then
+     !final state neutron blocking, C14
+     eta_np = neutron_number_density* &! # neutons/cm^3
+          max(0.0d0,(proton_number_density/neutron_number_density-1.0d0)/ & !final state proton blocking, =1 if blocking is irrelevant
+          (exp(-matter_muhat0/eos_variables(tempindex))-1.0d0)) !Bruenn 1985, Eq. C14
+     
+     !final state proton blocking, C14 with n swapped with p
+     eta_pn = proton_number_density* & ! # protons/cm^3
+          max(0.0d0,(neutron_number_density/proton_number_density-1.0d0)/ & !final state neutron blocking, =1 if blocking is irrelevant
+          (exp(matter_muhat0/eos_variables(tempindex))-1.0d0)) !Bruenn 1985, Eq. C14, with n and p switched
+  else
+     !no final state blocking
+     eta_np = neutron_number_density
+     eta_pn = proton_number_density
+  endif
+  
   !add in the electron neutrino absorption on free neutrons
   if (add_nue_absorption_on_n.and.neutrino_species.eq.1) then
 
-     !some low density, low temperature regions give issues with nucleon blocking, so if rho<1e11, assume no nulceon blocking
-     if (eos_variables(rhoindex).ge.1.0d11) then
-        absorption_opacity = absorption_opacity + & !total opacity, dimensions cm^-1
-             nue_absorption_on_n(neutrino_energy,eos_variables)* & !crosssection, cm^2
-             neutron_number_density* &! # neutons/cm^3
-             max(0.0d0,(proton_number_density/neutron_number_density-1.0d0)/ & !final state proton blocking, =1 if blocking is irrelevant
-             (exp(-matter_muhat0/eos_variables(tempindex))-1.0d0)) !Bruenn 1985, Eq. C14
-     else
-        absorption_opacity = absorption_opacity + & !total opacity, dimensions cm^-1
-             nue_absorption_on_n(neutrino_energy,eos_variables)* & !crosssection, cm^2
-             neutron_number_density! # neutons/cm^3
-     endif
+     absorption_opacity = absorption_opacity + & !total opacity, dimensions cm^-1
+          nue_absorption_on_n(neutrino_energy,eos_variables)* & !crosssection, cm^2 
+          eta_np !effective target density (taking blocking into account) #/cm^3
 
      !just a check
      if (absorption_opacity.ne.absorption_opacity) then
@@ -386,19 +395,9 @@ subroutine total_absorption_opacities(neutrino_species,neutrino_energy,absorptio
   !add in the electron antineutrino absorption on free protons
   if (add_anue_absorption_on_p.and.neutrino_species.eq.2) then
 
-     !use minus electron chemical potential, equals positron chemical potential
-     !some low density, low temperature regions give issues with nucleon blocking, so if rho<1e11, assume no nulceon blocking
-     if (eos_variables(rhoindex).ge.1.0d11) then
-        absorption_opacity = absorption_opacity + & ! total opacity, dimensions cm^-1
-             anue_absorption_on_p(neutrino_energy,eos_variables)* & !crosssection, cm^2
-             proton_number_density* & ! # protons/cm^3
-             max(0.0d0,(neutron_number_density/proton_number_density-1.0d0)/ & !final state neutron blocking, =1 if blocking is irrelevant
-             (exp(matter_muhat0/eos_variables(tempindex))-1.0d0)) !Bruenn 1985, Eq. C14, with n and p switched
-     else
-        absorption_opacity = absorption_opacity + & ! total opacity, dimensions cm^-1
-             anue_absorption_on_p(neutrino_energy,eos_variables)* & !crosssection, cm^2
-             proton_number_density ! # protons/cm^3
-     endif
+     absorption_opacity = absorption_opacity + & ! total opacity, dimensions cm^-1
+          anue_absorption_on_p(neutrino_energy,eos_variables)* & !crosssection, cm^2 
+          eta_pn !effective target density (taking blocking into account) #/cm^3
 
      !just a check
      if (absorption_opacity.ne.absorption_opacity) then

--- a/src/requested_interactions.inc
+++ b/src/requested_interactions.inc
@@ -10,6 +10,9 @@
   logical :: do_transport_opacities = .true.
   real*8, parameter :: gAs = -0.2d0 !dimensionless, for the strange coupling
 
+  !final state blocking options
+  logical :: do_breunn_final_state_nucleon_blocking = .true.
+
   !absorptions
   logical :: add_nue_absorption_on_n = .true.
   logical :: add_anue_absorption_on_p = .true.

--- a/src/requested_interactions.inc
+++ b/src/requested_interactions.inc
@@ -11,7 +11,8 @@
   real*8, parameter :: gAs = -0.2d0 !dimensionless, for the strange coupling
 
   !final state blocking options
-  logical :: do_breunn_final_state_nucleon_blocking = .true.
+  logical :: do_breunn_final_state_nucleon_blocking_abs = .true.
+  logical :: do_breunn_final_state_nucleon_blocking_scat = .true.
 
   !absorptions
   logical :: add_nue_absorption_on_n = .true.

--- a/src/scattering.F90
+++ b/src/scattering.F90
@@ -622,7 +622,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
   np = max(1.0d-100,eos_variables(xpindex))* &
        eos_variables(rhoindex)/(m_ref*mev_to_gram) !# protons/cm^3
 
-  if (do_breunn_final_state_nucleon_blocking) then
+  if (do_breunn_final_state_nucleon_blocking_scat) then
      !final state blocking a la Bruenn 1985 and weakhub/Mezzacappa & Bruenn 93
      ef_n = hbarc_mevcm**2/(2.0*m_ref)*(3.0*pi**2*nn)**(2.0/3.0)
      ef_p = hbarc_mevcm**2/(2.0*m_ref)*(3.0*pi**2*np)**(2.0/3.0)

--- a/src/scattering.F90
+++ b/src/scattering.F90
@@ -603,6 +603,10 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
   real*8 :: delta
   real*8 :: this_opacity
   integer :: transport
+  real*8 :: nn,np !number density of targets
+  real*8 :: ef_n,ef_p,xi_n,xi_p,eta_nn, eta_pp !for final state blocking
+  
+
   
   scattering_opacity = 0.0d0
   average_delta = 0.0d0

--- a/src/scattering.F90
+++ b/src/scattering.F90
@@ -623,7 +623,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
        eos_variables(rhoindex)/(m_ref*mev_to_gram) !# protons/cm^3
 
   if (do_breunn_final_state_nucleon_blocking) then
-     !final state blocking a la Bruenn 1985 and weakhub
+     !final state blocking a la Bruenn 1985 and weakhub/Mezzacappa & Bruenn 93
      ef_n = hbarc_mevcm**2/(2.0*m_ref)*(3.0*pi**2*nn)**(2.0/3.0)
      ef_p = hbarc_mevcm**2/(2.0*m_ref)*(3.0*pi**2*np)**(2.0/3.0)
      xi_n = 3.0*eos_variables(tempindex)/(2.0*ef_n)

--- a/src/scattering.F90
+++ b/src/scattering.F90
@@ -612,6 +612,24 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
   else
      transport = 0
   endif
+
+  nn = max(1.0d-100,eos_variables(xnindex))* &
+       eos_variables(rhoindex)/(m_ref*mev_to_gram) !# neutrons/cm^3
+  np = max(1.0d-100,eos_variables(xpindex))* &
+       eos_variables(rhoindex)/(m_ref*mev_to_gram) !# protons/cm^3
+
+  if (do_breunn_final_state_nucleon_blocking) then
+     !final state blocking a la Bruenn 1985 and weakhub
+     ef_n = hbarc_mevcm**2/(2.0*m_ref)*(3.0*pi**2*nn)**(2.0/3.0)
+     ef_p = hbarc_mevcm**2/(2.0*m_ref)*(3.0*pi**2*np)**(2.0/3.0)
+     xi_n = 3.0*eos_variables(tempindex)/(2.0*ef_n)
+     xi_p = 3.0*eos_variables(tempindex)/(2.0*ef_p)
+     eta_nn = nn*xi_n/sqrt(1.0+xi_n**2)
+     eta_pp = np*xi_p/sqrt(1.0+xi_p**2)
+  else
+     eta_nn = nn
+     eta_pp = np
+  endif
   
   !electron neutrino
   if (neutrino_species.eq.1) then
@@ -619,7 +637,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_nue_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = 1
         call nu_scatter_elastic_n_total(neutrino_energy,transport,1,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_nn
         scattering_opacity = scattering_opacity + this_opacity             
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -628,7 +646,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_nue_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = 1
         call nu_scatter_elastic_p_total(neutrino_energy,transport,1,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_pp
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -666,7 +684,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_anue_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = -1
         call nu_scatter_elastic_n_total(neutrino_energy,transport,-1,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_nn
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -675,7 +693,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_anue_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = -1
         call nu_scatter_elastic_p_total(neutrino_energy,transport,-1,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_pp
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -713,7 +731,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_numu_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = 2
         call nu_scatter_elastic_n_total(neutrino_energy,transport,2,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_nn
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -722,7 +740,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_numu_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = 2
         call nu_scatter_elastic_p_total(neutrino_energy,transport,2,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_pp
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -760,7 +778,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_anumu_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = -2
         call nu_scatter_elastic_n_total(neutrino_energy,transport,-2,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_nn
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -769,7 +787,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_anumu_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = -2
         call nu_scatter_elastic_p_total(neutrino_energy,transport,-2,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_pp
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -807,7 +825,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_nutau_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = 3
         call nu_scatter_elastic_n_total(neutrino_energy,transport,3,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_nn
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -816,7 +834,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_nutau_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = 3
         call nu_scatter_elastic_p_total(neutrino_energy,transport,3,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_pp
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -854,7 +872,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_anutau_scattering_n) then
         !function call takes neutrino energy, transport=1, lepton number = -3
         call nu_scatter_elastic_n_total(neutrino_energy,transport,-3,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xnindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_nn
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif
@@ -863,7 +881,7 @@ subroutine total_scattering_opacity(neutrino_species,neutrino_energy,scattering_
      if (add_anutau_scattering_p) then
         !function call takes neutrino energy, transport=1, lepton number = -3
         call nu_scatter_elastic_p_total(neutrino_energy,transport,-3,eos_variables,crosssection,delta)
-        this_opacity = crosssection * eos_variables(xpindex)*eos_variables(rhoindex)/(m_ref*mev_to_gram)
+        this_opacity = crosssection * eta_pp
         scattering_opacity = scattering_opacity + this_opacity
         average_delta      = average_delta      + this_opacity*delta
      endif


### PR DESCRIPTION
In previous versions on NuLib final state nucleon blocking was included for absorption cross sections only.  This PR adds final state blocking for scattering interactions on nucleons as well.

Furthermore, both of these final state blocking effects are now controllable from reqeusted_interactions.inc by the logical variables `do_breunn_final_state_nucleon_blocking_abs` and `do_breunn_final_state_nucleon_blocking_scat`.

These are not really recommended to set as .false. as this effect can be important, but for those who want to apply their own final state blocking, or for future options for other prescriptions this may be useful. To maintain compatibility with previous NuLib tables where final state block on nucleons for scattering processes wasn't included, set do_breunn_final_state_nucleon_blocking_scat to .false.

