### PR TITLE
Update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,6 @@ ifeq ($(DEBUG),1)
 endif
 
 ifeq ($(MPI),1)
-	F90 = mpif90
 	DEFS += -D__MPI__
 endif
 


### PR DESCRIPTION
remove the under-the-hood reset of the F90 executable to mpif90.  The user will have to specify the mpi compiler in the make.inc file as normal.